### PR TITLE
Fixed noInterestInstallmentQuantity Parameter Support

### DIFF
--- a/lib/pagseguro/payment.rb
+++ b/lib/pagseguro/payment.rb
@@ -49,9 +49,9 @@ module PagSeguro
 
     attr_accessor :extra_amount
 
-    # Set the max installments with no interest.
+    # Set the max installment with no interest.
     # Optional.
-    attr_accessor :max_installments_no_interest
+    attr_accessor :max_installment_no_interest
 
     # Products/items in this payment request.
     def items

--- a/lib/pagseguro/payment/serializer.rb
+++ b/lib/pagseguro/payment/serializer.rb
@@ -16,12 +16,7 @@ module PagSeguro
         params[:paymentMode] = payment.payment_mode
         params[:reference] = payment.reference
         params[:extraAmount] = payment.extra_amount
-
-        if payment.max_installments_no_interest
-          params[:paymentMethodGroup1] ='CREDIT_CARD'
-          params[:paymentMethodConfigKey1_1] ='MAX_INSTALLMENTS_NO_INTEREST'
-          params[:paymentMethodConfigValue1_1] = payment.max_installments_no_interest
-        end
+        params[:noInterestInstallmentQuantity] = payment.max_installment_no_interest
 
         payment.items.each.with_index(1) do |item, index|
           serialize_item(item, index)

--- a/lib/pagseguro/version.rb
+++ b/lib/pagseguro/version.rb
@@ -1,3 +1,3 @@
 module PagSeguro
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/spec/pagseguro/payment/serializer_spec.rb
+++ b/spec/pagseguro/payment/serializer_spec.rb
@@ -19,7 +19,7 @@ describe PagSeguro::Payment::Serializer do
     payment.shipping = shipping
     payment.credit_card = credit_card
     payment.bank = bank
-    payment.max_installments_no_interest = 6
+    payment.max_installment_no_interest = 6
     payment.items = [PagSeguro::Item.new(id: '0001', description: 'Notebook Prata', amount: '24300.00', quantity: '1') ,
     PagSeguro::Item.new(id: '0002', description: 'Notebook Rosa', amount: '25600.00', quantity: '2') ]
     payment
@@ -130,9 +130,7 @@ describe PagSeguro::Payment::Serializer do
   it { subject[:itemAmount2].should eq('25600.00') }
   it { subject[:itemQuantity2].should eq('2') }
 
-  it { subject[:paymentMethodGroup1].should eq('CREDIT_CARD') }
-  it { subject[:paymentMethodConfigKey1_1].should eq('MAX_INSTALLMENTS_NO_INTEREST') }
-  it { subject[:paymentMethodConfigValue1_1].should eq(6) }
+  it { subject[:noInterestInstallmentQuantity].should eq(6) }
 
   context 'with bithdate null' do
     let(:holder) do

--- a/spec/pagseguro/payment_spec.rb
+++ b/spec/pagseguro/payment_spec.rb
@@ -65,7 +65,7 @@ describe PagSeguro::Payment do
   it { should respond_to(:shipping) }
   it { should respond_to(:bank) }
   it { should respond_to(:credit_card) }
-  it { should respond_to(:max_installments_no_interest) }
+  it { should respond_to(:max_installment_no_interest) }
 
   describe 'presence validations' do
     it { should validate_presence_of(:currency) }


### PR DESCRIPTION
The parameter noInterestInstallmentQuantity was named incorrectly, fixed.
The serializer class treated the parameter noInterestInstallmentQuantity wrongly, fixed.